### PR TITLE
repeat mode for image source

### DIFF
--- a/grc/paint_image_source.xml
+++ b/grc/paint_image_source.xml
@@ -4,7 +4,7 @@
   <key>paint_image_source</key>
   <category>Paint</category>
   <import>import paint</import>
-  <make>paint.image_source($image_file, $image_flip, $bt709_map, $image_invert, $autocontrast)</make>
+  <make>paint.image_source($image_file, $image_flip, $bt709_map, $image_invert, $autocontrast, $repeatmode)</make>
   <param>
     <name>Image File</name>
     <key>image_file</key>
@@ -65,6 +65,24 @@
     <option>
       <name>Yes</name>
       <key>1</key>
+    </option>
+  </param>
+  <param>
+    <name>Repeat</name>
+    <key>repeatmode</key>
+    <value>Yes</value>
+    <type>enum</type>
+    <option>
+      <name>No</name>
+      <key>0</key>
+    </option>
+    <option>
+      <name>Yes</name>
+      <key>1</key>
+    </option>
+    <option>
+      <name>Yes, with file re-read</name>
+      <key>2</key>
     </option>
   </param>
   <source>

--- a/python/image_source.py
+++ b/python/image_source.py
@@ -2,7 +2,7 @@
 # vim: tabstop=4:softtabstop=4:shiftwidth=4:noexpandtab:
 # -*- coding: utf-8 -*-
 # 
-# Copyright 2015 Chris Kuethe <chris.kuethe@gmail.com>
+# Copyright 2015,2016 Chris Kuethe <chris.kuethe@gmail.com>
 # 
 # This is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -31,45 +31,69 @@ class image_source(gr.sync_block):
 	Given an image file readable by Python-Imaging, this block produces
 	monochrome lines suitable for input to spectrum_paint
 	"""
-	def __init__(self, image_file, image_flip=False, bt709_map=True, image_invert=False, autocontrast=False):
+
+	image_file = None
+	image_flip = False
+	bt709_map = True
+	image_invert = False
+	autocontrast = False
+	repeatmode = 1
+	image_data = None
+	eof = False
+
+	def __init__(self, image_file, image_flip=False, bt709_map=True, image_invert=False, autocontrast=False, repeatmode=1):
 		gr.sync_block.__init__(self,
 			name="image_source",
 			in_sig=None,
 			out_sig=[numpy.uint8])
 
-		im = Image.open(image_file)
-		im = ImageOps.grayscale(im)
+		self.image_file = image_file
+		self.image_flip = image_flip
+		self.bt709_map = bt709_map
+		self.image_invert = image_invert
+		self.autocontrast = autocontrast
+		self.repeatmode = repeatmode
 
-		if autocontrast:
+		self.load_image()
+
+	def load_image(self):
+		"""decode the image into a buffer"""
+		self.image_data = Image.open(self.image_file)
+		self.image_data = ImageOps.grayscale(self.image_data)
+
+		if self.autocontrast:
 			# may or may not improve the look of the transmitted spectrum
-			im = ImageOps.autocontrast(im)
+			self.image_data = ImageOps.autocontrast(self.image_data)
 
-		if image_invert:
+		if self.image_invert:
 			# may or may not improve the look of the transmitted spectrum
-			im = ImageOps.invert(im)
+			self.image_data = ImageOps.invert(self.image_data)
 
-		if image_flip:
+		if self.image_flip:
 			# set to true for waterfalls that scroll from the top
-			im = ImageOps.flip(im)
+			self.image_data = ImageOps.flip(self.image_data)
 
-		(self.image_width, self.image_height) = im.size
-		max_width = 2048.0
+		(self.image_width, self.image_height) = self.image_data.size
+		max_width = 4096.0
 		if self.image_width > max_width:
 			scaling = max_width / self.image_width
 			newsize = (int(self.image_width * scaling), int(self.image_height * scaling))
 			(self.image_width, self.image_height) = newsize
-			im = im.resize(newsize)
+			self.image_data = self.image_data.resize(newsize)
 		self.set_output_multiple(self.image_width)
 
-		self.image_data = list(im.getdata())
-		if bt709_map:
+		self.image_data = list(self.image_data.getdata())
+		if self.bt709_map:
 			# scale brightness according to ITU-R BT.709
 			self.image_data = map( lambda x: x * 219 / 255 + 16,  self.image_data)
 		self.image_len = len(self.image_data)
-		print "paint.image_source: %d bytes, %dpx width" % (self.image_len, self.image_width)
+		if self.repeatmode != 2:
+			print "paint.image_source: %d bytes, %dpx width" % (self.image_len, self.image_width)
 		self.line_num = 0
 
 	def work(self, input_items, output_items):
+		if self.eof:
+			return -1
 		out = output_items[0]
 		self.add_item_tag(0, self.nitems_written(0), pmt.intern("image_width"), pmt.from_long(self.image_width))
 		self.add_item_tag(0, self.nitems_written(0), pmt.intern("line_num"), pmt.from_long(self.line_num))
@@ -78,4 +102,8 @@ class image_source(gr.sync_block):
 		self.line_num += 1
 		if self.line_num >= self.image_height:
 			self.line_num = 0
+			if self.repeatmode == 0:
+				self.eof = True
+			if self.repeatmode == 2:
+				self.load_image()
 		return self.image_width


### PR DESCRIPTION
The difference between repeat modes is that mode 1 decodes the image to a buffer and then continuously emits lines; mode 2 will re-open the source file after emitting the last line allowing thus allowing the the transmitted image to be changed by swapping out the file on disk.

Example:https://imgur.com/tKNgA9Q

Also, increase the maximum output size to 4096, to match the maximum imput size of the painter block.
