### PR TITLE
Fix buffer overflow and broken YML

### DIFF
--- a/grc/paint_paint_bc.block.yml
+++ b/grc/paint_paint_bc.block.yml
@@ -25,7 +25,7 @@ parameters:
     dtype: enum
     options: [INTERNAL, EXTERNAL]
     option_attributes:
-        ports: ['1', '2']
+        ports: [1, 2]
         val: [paint.INTERNAL, paint.EXTERNAL]
     hide: part
 

--- a/lib/paint_bc_impl.cc
+++ b/lib/paint_bc_impl.cc
@@ -105,7 +105,13 @@ namespace gr {
                        gr_vector_void_star &output_items)
     {
         const unsigned char *in = (const unsigned char *) input_items[0];
-        const unsigned char *in_rand = (const unsigned char *) input_items[1];
+        const unsigned char *in_rand = nullptr;
+
+        if (random_source == EXTERNAL)
+        {
+            in_rand = (const unsigned char *) input_items[1];
+        }
+
         gr_complex *out = (gr_complex *) output_items[0];
         int consumed = 0;
         int consumed_rand = 0;


### PR DESCRIPTION
gr-paint has the same bugs as were fixed in https://github.com/gnuradio/gnuradio/pull/6346:

* buffer overrun when reading `input_items` in the `random_source == INTERNAL` case
* `ports` should be an integer, not a string

After these fixes, the external random input works, and the buffer overrun is gone.

Valgrind report:
```
==410619== Thread 31 paint_bc1:
==410619== Invalid read of size 8
==410619==    at 0x4DAB0902: gr::paint::paint_bc_impl::general_work(int, std::vector<int, std::allocator<int> >&, std::vector<void const*, std::allocator<void const*> >&, std::vector<void*, std::allocator<void*> >&) (paint_bc_impl.cc:108)
==410619==    by 0x610BBDA: gr::block_executor::run_one_iteration() (block_executor.cc:623)
==410619==    by 0x61711DA: gr::tpb_thread_body::tpb_thread_body(std::shared_ptr<gr::block>, std::shared_ptr<boost::barrier>, int) (tpb_thread_body.cc:94)
==410619==    by 0x6159909: operator() (scheduler_tpb.cc:38)
==410619==    by 0x6159909: operator() (thread_body_wrapper.h:49)
==410619==    by 0x6159909: __invoke_impl<void, gr::thread::thread_body_wrapper<gr::tpb_container>&> (invoke.h:61)
==410619==    by 0x6159909: __invoke_r<void, gr::thread::thread_body_wrapper<gr::tpb_container>&> (invoke.h:111)
==410619==    by 0x6159909: std::_Function_handler<void (), gr::thread::thread_body_wrapper<gr::tpb_container> >::_M_invoke(std::_Any_data const&) (std_function.h:290)
==410619==    by 0x688A0CA: ??? (in /usr/lib/x86_64-linux-gnu/libboost_thread.so.1.74.0)
==410619==    by 0x4A3FB42: start_thread (pthread_create.c:442)
==410619==    by 0x4AD0BB3: clone (clone.S:100)
==410619==  Address 0x4b5e15b8 is 0 bytes after a block of size 8 alloc'd
==410619==    at 0x4849013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==410619==    by 0x610DEBA: allocate (new_allocator.h:127)
==410619==    by 0x610DEBA: allocate (alloc_traits.h:464)
==410619==    by 0x610DEBA: _M_allocate (stl_vector.h:346)
==410619==    by 0x610DEBA: std::vector<void const*, std::allocator<void const*> >::_M_default_append(unsigned long) (vector.tcc:635)
==410619==    by 0x610BAB3: resize (stl_vector.h:940)
==410619==    by 0x610BAB3: gr::block_executor::run_one_iteration() (block_executor.cc:409)
==410619==    by 0x61711DA: gr::tpb_thread_body::tpb_thread_body(std::shared_ptr<gr::block>, std::shared_ptr<boost::barrier>, int) (tpb_thread_body.cc:94)
==410619==    by 0x6159909: operator() (scheduler_tpb.cc:38)
==410619==    by 0x6159909: operator() (thread_body_wrapper.h:49)
==410619==    by 0x6159909: __invoke_impl<void, gr::thread::thread_body_wrapper<gr::tpb_container>&> (invoke.h:61)
==410619==    by 0x6159909: __invoke_r<void, gr::thread::thread_body_wrapper<gr::tpb_container>&> (invoke.h:111)
==410619==    by 0x6159909: std::_Function_handler<void (), gr::thread::thread_body_wrapper<gr::tpb_container> >::_M_invoke(std::_Any_data const&) (std_function.h:290)
==410619==    by 0x688A0CA: ??? (in /usr/lib/x86_64-linux-gnu/libboost_thread.so.1.74.0)
==410619==    by 0x4A3FB42: start_thread (pthread_create.c:442)
==410619==    by 0x4AD0BB3: clone (clone.S:100)
```